### PR TITLE
Feature: 로그인 API를 위한 인증 프로세스 를 커스터마이징한다.

### DIFF
--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationFilter.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package moon.thinkhard.spring_security_template.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import moon.thinkhard.spring_security_template.authentication.dto.LoginRequest;
+import moon.thinkhard.spring_security_template.handler.CustomAuthenticationFailureHandler;
+import moon.thinkhard.spring_security_template.handler.CustomAuthenticationSuccessHandler;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.io.IOException;
+
+public class CustomAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+    private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = new AntPathRequestMatcher("/login", "POST");
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super(DEFAULT_ANT_PATH_REQUEST_MATCHER, authenticationManager);
+        this.objectMapper = new ObjectMapper();
+        setAuthenticationFailureHandler(new CustomAuthenticationFailureHandler());
+        setAuthenticationSuccessHandler(new CustomAuthenticationSuccessHandler());
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException {
+        LoginRequest requestBody = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+
+        Authentication authRequest = new CustomAuthenticationToken(requestBody.getId(), requestBody.getPassword());
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationProvider.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationProvider.java
@@ -1,0 +1,35 @@
+package moon.thinkhard.spring_security_template.authentication;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+    private final Log logger;
+
+    public CustomAuthenticationProvider() {
+        this.logger = LogFactory.getLog(getClass());
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        logger.info("Invoking CustomAuthenticationProvider.authenticate(Authentication)");
+
+        return null;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        logger.info("Invoking CustomAuthenticationProvider.supports(Class<?>)");
+        logger.info(String.format("authentication class name : %s", authentication.getName()));
+
+        return (CustomAuthenticationToken.class.isAssignableFrom(authentication));
+    }
+
+    // retrieveUser() override
+    // userDetailsService create(implementation), loadUserByUsername() override
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationProvider.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationProvider.java
@@ -3,33 +3,98 @@ package moon.thinkhard.spring_security_template.authentication;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
+/**
+ * CustomAuthenticationToken 객체에 대해 인증 처리하는 클래스.
+ */
 @Component
 public class CustomAuthenticationProvider implements AuthenticationProvider {
     private final Log logger;
+    private final UserDetailsService userDetailsService;
 
-    public CustomAuthenticationProvider() {
+    public CustomAuthenticationProvider(UserDetailsService userDetailsService) {
         this.logger = LogFactory.getLog(getClass());
+        this.userDetailsService = userDetailsService;
     }
 
+    /**
+     * 인증을 수행한다.
+     * @param authentication 인증 전 Authentication 객체
+     * @return credentials를 포함하는 완전히 인증된 객체.
+     * 만약 지원할 수 없는 Authentication이라면 null을 반환할 수 있다.
+     * 이런 경우, 다음 AuthenticationProvider 가 주어진 인증 객체를 지원할 수 있는지 시도한다.
+     * @throws AuthenticationException 인증에 실패할 경우 발생한다.
+     */
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         logger.info("Invoking CustomAuthenticationProvider.authenticate(Authentication)");
+        if (!supports(authentication.getClass())) {
+            return null;
+        }
+        // authentication isInstanceOf check
+/*
+        Assert.isInstanceOf(CustomAuthenticationToken.class, authentication,
+                () -> this.messages.getMessage("CustomAuthenticationProvider.onlySupports",
+                        "Only CustomAuthenticationToken is supported"));
+*/
 
-        return null;
+        String username = determineUsername(authentication);
+        UserDetails user = retrieveUser(username);
+        return createSuccessAuthentication(username, authentication, user);
     }
 
+    /**
+     * 인증에 성공하는 경우 필요한 사용자 정보를 담을 수 있는 Custom Authentication 객체를 생성하여 반환한다.
+     * @param principal 사용자 관련 정보 (id/username, 사용자 이름 ..)
+     * @param authentication 인증 전 Authentication 객체
+     * @param user 사용자 정보를 담는 UserDetails 객체
+     * @return 인증에 성공한 Authentication 객체
+     */
+    private Authentication createSuccessAuthentication(String principal, Authentication authentication, UserDetails user) {
+        // TODO password encoding 여부 결정 필요.
+        // this.passwordEncoder.encode(authentication.getCredentials())
+        logger.debug("Authenticated User");
+        return CustomAuthenticationToken.authenticated(principal, authentication.getCredentials(), user.getAuthorities());
+    }
+
+    private String determineUsername(Authentication authentication) {
+        return (authentication.getPrincipal() == null) ? "NONE_PROVIDED" : authentication.getName();
+    }
+
+    /**
+     * UserDetailsService 를 통해 UserDetails 객체를 조회해서 반환한다.
+     * @param username 사용자 username
+     * @return username에 해당하는 UserDetails
+     */
+    private UserDetails retrieveUser(String username) {
+        try {
+            UserDetails loadedUser = this.userDetailsService.loadUserByUsername(username);
+
+            if (loadedUser == null) {
+                throw new UsernameNotFoundException(String.format("UserDetailsService returned null. (username: '%s')", username));
+            }
+            return loadedUser;
+        } catch (Exception ex) {
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * CustomAuthenticationProvider가 지원하는 Authentication 객체인지 판단한다.
+     * @param authentication Authentication 객체 구현체
+     * @return 인증 처리를 지원하는 Authentication 객체라면 True
+     */
     @Override
     public boolean supports(Class<?> authentication) {
         logger.info("Invoking CustomAuthenticationProvider.supports(Class<?>)");
-        logger.info(String.format("authentication class name : %s", authentication.getName()));
 
         return (CustomAuthenticationToken.class.isAssignableFrom(authentication));
     }
-
-    // retrieveUser() override
-    // userDetailsService create(implementation), loadUserByUsername() override
 }

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationToken.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationToken.java
@@ -1,0 +1,64 @@
+package moon.thinkhard.spring_security_template.authentication;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import java.util.Collection;
+
+public class CustomAuthenticationToken implements Authentication {
+    private final Object principal;
+    private final Object credentials;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomAuthenticationToken(Object principal, Object credentials) {
+        this(principal, credentials, AuthorityUtils.NO_AUTHORITIES);
+    }
+
+    private CustomAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        this.principal = principal;
+        this.credentials = credentials;
+        this.authorities = authorities;
+    }
+
+    public static CustomAuthenticationToken authenticated(Object principal, Object credentials,
+                                                          Collection<? extends GrantedAuthority> authorities) {
+        return new CustomAuthenticationToken(principal, credentials, authorities);
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationToken.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomAuthenticationToken.java
@@ -6,9 +6,21 @@ import org.springframework.security.core.authority.AuthorityUtils;
 
 import java.util.Collection;
 
+/**
+ * Spring Security에서 사용자 인증을 표현한다. 사용자의 자격증명을 캡슐화하고 인증상태를 관리하는 것이 목적이다.
+ */
 public class CustomAuthenticationToken implements Authentication {
+    /**
+     * 사용자와 관련된 정보로, 일반적으로 인증 전에는 사용자 이름(id/username), 인증 후에는 UserDetails 객체 혹은 사용자 이름이 세팅된다.
+     */
     private final Object principal;
+    /**
+     * 인증을 위해 제출된 자격증명으로, 일반적으로 인증 전에는 password가 세팅된다. 인증 후에는 보안 상 null이 세팅될 수 있다.
+     */
     private final Object credentials;
+    /**
+     * 사용자의 권한 정보로, 인증 전에는 빈 Collection, 인증 후에는 사용자의 권한 값이 세팅된다.
+     */
     private final Collection<? extends GrantedAuthority> authorities;
 
     public CustomAuthenticationToken(Object principal, Object credentials) {
@@ -26,17 +38,20 @@ public class CustomAuthenticationToken implements Authentication {
         return new CustomAuthenticationToken(principal, credentials, authorities);
     }
 
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return authorities;
     }
 
     @Override
     public Object getCredentials() {
-        return null;
+        return credentials;
     }
 
+    /**
+     * @return 요청 데이터/정보로부터 알 수 있는 정보 (IP, 요청 Client 정보-RemoteAddr, SessionId 등) 객체 <br>
+     *          ex) WebAuthenticationDetails
+     */
     @Override
     public Object getDetails() {
         return null;
@@ -44,21 +59,27 @@ public class CustomAuthenticationToken implements Authentication {
 
     @Override
     public Object getPrincipal() {
-        return null;
+        return principal;
     }
 
+    /**
+     * 인증 필터를 직접 커스터마이징한다면, 실제 호출되지 않음.
+     * @return 인증에 성공한 객체인지 여부
+     */
     @Override
     public boolean isAuthenticated() {
         return false;
     }
 
+    /**
+     * 인증 필터를 직접 커스터마이징한다면, 실제 호출되지 않음.
+     */
     @Override
     public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
-
     }
 
     @Override
     public String getName() {
-        return null;
+        return principal.toString();
     }
 }

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomGrantedAuthority.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomGrantedAuthority.java
@@ -1,0 +1,16 @@
+package moon.thinkhard.spring_security_template.authentication;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public class CustomGrantedAuthority implements GrantedAuthority {
+    private final UserRole role;
+
+    public CustomGrantedAuthority(UserRole role) {
+        this.role = role;
+    }
+
+    @Override
+    public String getAuthority() {
+        return null;
+    }
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomUserDetails.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package moon.thinkhard.spring_security_template.authentication;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.Assert;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class CustomUserDetails implements UserDetails {
+    private final String username;
+    private final String password;
+
+    private final Set<GrantedAuthority> authorities;
+    private final boolean accountNonLocked;
+    private final boolean enabled;
+
+
+    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities,
+                             boolean accountNonLocked, boolean enabled) {
+        Assert.isTrue(username != null && !"".equals(username) && password != null,
+                "Cannot pass null or empty values to constructor");
+
+        this.username = username;
+        this.password = password;
+        this.authorities = Set.copyOf(authorities);
+        this.accountNonLocked = accountNonLocked;
+        this.enabled = enabled;
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return isEnabled();
+    }
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomUserDetailsService.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package moon.thinkhard.spring_security_template.authentication;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+
+/**
+ * 사용자를 특정하는 데이터를 로드하는 주요 인터페이스로, CustomAuthenticationProvider에서 사용하는 전략이다.
+ */
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+    /**
+     * username에 기반하여 사용자를 반환한다.
+     * @param username 데이터가 필요한 사용자를 식별하는 username
+     * @return 완전히 채워진 user 데이터 반환 (null이 나오지 않음.)
+     * @throws UsernameNotFoundException 사용자가 존재하지 않으면 발생한다.
+     */
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // TODO 권한, 잠금 여부, 활성화 여부 조회를 포함한 사용자 정보 조회 SQL
+        //  Test Data
+        return new CustomUserDetails(username, "password", new HashSet<>(), true, true);
+    }
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/UserRole.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/UserRole.java
@@ -1,0 +1,14 @@
+package moon.thinkhard.spring_security_template.authentication;
+
+public enum UserRole {
+    MEMBER_SUPER("ROLE_MEMBER_SUPER"),
+    MEMBER_GENERAL("ROLE_MEMBER_GENERAL"),
+    NON_MEMBER("ROLE_NON_MEMBER")
+    ;
+
+    private final String role;
+
+    UserRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/authentication/dto/LoginRequest.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/authentication/dto/LoginRequest.java
@@ -1,0 +1,23 @@
+package moon.thinkhard.spring_security_template.authentication.dto;
+
+
+public class LoginRequest {
+    private String id;
+    private String password;
+
+    protected LoginRequest() {
+    }
+
+    public LoginRequest(String id, String password) {
+        this.id = id;
+        this.password = password;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/config/SecurityConfig.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/config/SecurityConfig.java
@@ -1,10 +1,10 @@
 package moon.thinkhard.spring_security_template.config;
 
 import moon.thinkhard.spring_security_template.authentication.CustomAuthenticationFilter;
-import moon.thinkhard.spring_security_template.authentication.CustomAuthenticationProvider;
 import moon.thinkhard.spring_security_template.handler.CustomAccessDeniedHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,9 +20,9 @@ import org.springframework.security.web.header.writers.XXssProtectionHeaderWrite
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
-    private final CustomAuthenticationProvider customAuthenticationProvider;
+    private final AuthenticationProvider customAuthenticationProvider;
 
-    public SecurityConfig(CustomAuthenticationProvider customAuthenticationProvider) {
+    public SecurityConfig(AuthenticationProvider customAuthenticationProvider) {
         this.customAuthenticationProvider = customAuthenticationProvider;
     }
 

--- a/src/main/java/moon/thinkhard/spring_security_template/config/SecurityConfigWithFormLogin.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/config/SecurityConfigWithFormLogin.java
@@ -1,0 +1,57 @@
+package moon.thinkhard.spring_security_template.config;
+
+import moon.thinkhard.spring_security_template.handler.CustomAuthenticationFailureHandler;
+import moon.thinkhard.spring_security_template.handler.CustomAuthenticationSuccessHandler;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
+import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
+
+/**
+ * Spring Security 에서 제공하는 폼 로그인을 사용할 경우 22-23 라인을 주석 해제 후 이용하세요.
+ */
+//@EnableWebSecurity
+//@Configuration
+public class SecurityConfigWithFormLogin {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .headers(header -> header
+                        .httpStrictTransportSecurity(hstsConfig -> hstsConfig.maxAgeInSeconds(31536000).includeSubDomains(true).preload(true))
+                        .contentSecurityPolicy(cspConfig -> cspConfig.policyDirectives("default-src 'self' object-src 'none' script-src 'none' style-src 'none"))
+                        .xssProtection(xssProtection -> xssProtection.headerValue(XXssProtectionHeaderWriter.HeaderValue.ENABLED_MODE_BLOCK))
+                        .referrerPolicy(referrerPolicyConfig -> referrerPolicyConfig.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER))
+                )
+                .sessionManagement(sessionManagementConfig -> sessionManagementConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizeRequest ->
+                        authorizeRequest.requestMatchers("/loginPage.html", "/error").permitAll()
+                                .requestMatchers("/nonMember").hasAuthority("read")
+                                .anyRequest().authenticated())
+                .formLogin(login ->
+                         login
+                                 .loginPage("/loginPage.html")
+                                 .usernameParameter("id")
+                                 .passwordParameter("password")
+                                 .loginProcessingUrl("/login")
+                                 .successHandler(new CustomAuthenticationSuccessHandler())
+                                 .failureHandler(new CustomAuthenticationFailureHandler())
+                                 .permitAll()
+                )
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+}

--- a/src/main/java/moon/thinkhard/spring_security_template/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/moon/thinkhard/spring_security_template/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package moon.thinkhard.spring_security_template.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+/**
+ * 요청한 리소스에 접근할 권한이 없을 때 AccessDeniedException이 발생하며, 이 핸들러가 이를 처리합니다.
+ */
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final Log logger;
+
+    public CustomAccessDeniedHandler() {
+        this.logger = LogFactory.getLog(getClass());
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        logger.info("Invoking CustomAccessDeniedHandler.handle(request, response, accessDeniedException)");
+
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        response.setHeader("Content-Type", "text/plain;charset=UTF-8");
+        response.getWriter().write("🤖 Your access is denied. Please log in again.");
+        response.sendRedirect("/loginPage.html");
+    }
+}

--- a/src/main/resources/static/loginPage.html
+++ b/src/main/resources/static/loginPage.html
@@ -57,7 +57,7 @@
 <body>
 <div class="login-container">
     <h1>로그인</h1>
-    <form action="/" method="post">
+    <form action="/login" method="post">
         <div>
             <label for="memberType">회원 종류:</label>
             <select id="memberType" name="memberType" required>


### PR DESCRIPTION
## 구현 사항
- 폼 로그인은 비활성화한다. (추후 원하는 경우 활성화할 수 있도록 템플릿화하였다.)
- id와 password를 입력하면, Body에 값을 담아 요청한다.  -> `LoginRequest.java`
- 추후 회원 별 Role이 있으므로 권한 관리를 할 수 있도록 한다.
- 로그인 성공/실패, 권한 이슈 발생 시 필요한 로직을 처리할 핸들러를 구현한다.
- 인증 처리 중 커스터마이징해야하는 필터 및 토큰은 각자 알맞은 상속받는 클래스를 생성한다.
  - `CustomAuthenticationProvider.java`
  - `CustomAuthenticationToken.java`
- username을 이용해 사용자를 로드하는 `UserDetailsService.java`, 값이 채워져 반환되는 사용자 데이터 `UserDetails.java`를 커스터마이징한다. (뼈대만 구성)
- `GrantedAuthority`를 커스터마이징하여 서비스에서 관리하고자 하는 권한을 필드로 갖는다.
  - 권한 요소는 Enum 클래스로 관리한다. (`UserRole.java`)